### PR TITLE
ACK runtime update to v0.19.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-04-29T23:10:13Z"
-  build_hash: 92aec8dac9ebb11cd5c84dede1e7f1d6c016c36f
-  go_version: go1.17.8
-  version: v0.18.4-5-g92aec8d
+  build_date: "2022-06-14T05:16:24Z"
+  build_hash: a133935a9a93591a9e1ba9d5ca940cb83a1353b4
+  go_version: go1.17.5
+  version: v0.19.0
 api_directory_checksum: e24b7145c773b9ff8377bba0f4a517ef86ca540c
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: c682f74a05d599fcc512b4616e55dafba41085f2
+  file_checksum: c4377deae6f80cba12d040e0e507069f345238eb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -31,3 +31,5 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/hosted_zone/sdk_create_post_build_request.go.tpl
+    tags:
+      ignore: true

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackrtutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	ackrtwebhook "github.com/aws-controllers-k8s/runtime/pkg/webhook"
 	svcsdk "github.com/aws/aws-sdk-go/service/route53"
@@ -101,7 +102,7 @@ func main() {
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup, awsServiceEndpointsID,
-		ackrt.VersionInfo{
+		acktypes.VersionInfo{
 			version.GitCommit,
 			version.GitVersion,
 			version.BuildDate,

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -66,7 +66,7 @@ spec:
         - name: ACK_LOG_LEVEL
           value: "info"
         - name: ACK_RESOURCE_TAGS
-          value: "services.k8s.aws/managed=true,services.k8s.aws/created=%UTCNOW%,services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%"
+          value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/generator.yaml
+++ b/generator.yaml
@@ -31,3 +31,5 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/hosted_zone/sdk_create_post_build_request.go.tpl
+    tags:
+      ignore: true

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/aws-controllers-k8s/route53-controller
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.18.4
+	github.com/aws-controllers-k8s/runtime v0.19.0
 	github.com/aws/aws-sdk-go v1.42.0
+	github.com/go-logr/logr v1.2.0
 	github.com/spf13/pflag v1.0.5
+	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
 	sigs.k8s.io/controller-runtime v0.11.0
@@ -18,7 +20,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -56,7 +57,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.23.0 // indirect
 	k8s.io/apiextensions-apiserver v0.23.0 // indirect
 	k8s.io/component-base v0.23.0 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.18.4 h1:iwLYNwhbuiWZrHPoulGj75oT+alE91wCNkF1FUELiAw=
-github.com/aws-controllers-k8s/runtime v0.18.4/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
+github.com/aws-controllers-k8s/runtime v0.19.0 h1:+O5a6jBSBAd8XTNMrVCIYu4G+ZUPZe/G5eopVFO18Dc=
+github.com/aws-controllers-k8s/runtime v0.19.0/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
 github.com/aws/aws-sdk-go v1.42.0 h1:BMZws0t8NAhHFsfnT3B40IwD13jVDG5KerlRksctVIw=
 github.com/aws/aws-sdk-go v1.42.0/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -64,9 +64,8 @@ installScope: cluster
 resourceTags:
   # Configures the ACK service controller to always set key/value pairs tags on
   # resources that it manages.
-  - services.k8s.aws/managed=true
-  - services.k8s.aws/created=%UTCNOW%
-  - services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%
+  - services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%
+  - services.k8s.aws/namespace=%K8S_NAMESPACE%
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/pkg/resource/hosted_zone/manager.go
+++ b/pkg/resource/hosted_zone/manager.go
@@ -27,19 +27,25 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	"github.com/aws/aws-sdk-go/aws/session"
+	svcsdk "github.com/aws/aws-sdk-go/service/route53"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
-	svcsdk "github.com/aws/aws-sdk-go/service/route53"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/route53/route53iface"
+	svcapitypes "github.com/aws-controllers-k8s/route53-controller/apis/v1alpha1"
 )
 
 var (
 	_ = ackutil.InStrings
+	_ = acktags.NewTags()
+	_ = ackrt.MissingImageTagValue
+	_ = svcapitypes.HostedZone{}
 )
 
 // +kubebuilder:rbac:groups=route53.services.k8s.aws,resources=hostedzones,verbs=get;list;watch;create;update;patch;delete
@@ -257,6 +263,22 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 	}
 
 	return true, nil
+}
+
+// EnsureTags ensures that tags are present inside the AWSResource.
+// If the AWSResource does not have any existing resource tags, the 'tags'
+// field is initialized and the controller tags are added.
+// If the AWSResource has existing resource tags, then controller tags are
+// added to the existing resource tags without overriding them.
+// If the AWSResource does not support tags, only then the controller tags
+// will not be added to the AWSResource.
+func (rm *resourceManager) EnsureTags(
+	ctx context.Context,
+	res acktypes.AWSResource,
+	md acktypes.ServiceControllerMetadata,
+) error {
+
+	return nil
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/hosted_zone/sdk.go
+++ b/pkg/resource/hosted_zone/sdk.go
@@ -171,6 +171,8 @@ func (rm *resourceManager) sdkCreate(
 	// You must use a unique CallerReference string every time you submit a
 	// CreateHostedZone request. CallerReference can be any unique string, for
 	// example, a date/timestamp.
+	// TODO: Name is not sufficient, since a failed request cannot be retried.
+	// We might need to import the `time` package into `sdk.go`
 	input.SetCallerReference(getCallerReference(desired.ko))
 
 	var resp *svcsdk.CreateHostedZoneOutput


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1341

Description of changes:
* Update ACK runtime to v0.19.0
* ignore tags for HostedZone because it does not support AWS tags

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
