### PR TITLE
Nullpoint Exception via RecordType when adopted resource

### DIFF
--- a/pkg/resource/record_set/resource.go
+++ b/pkg/resource/record_set/resource.go
@@ -95,6 +95,10 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 		r.ko.Spec.HostedZoneID = &f0
 	}
 
+	f1, f1ok := identifier.AdditionalKeys["recordType"]
+	if f1ok {
+		r.ko.Spec.RecordType = &f1
+	}
 	return nil
 }
 


### PR DESCRIPTION
Issue #, if available:
[#2108](https://github.com/aws-controllers-k8s/community/issues/2108)
Description of changes:

A null pointer exception occurred while comparing recordType, so the recordType was retrieved from the additionalKeys in the adopted Resource and updated in the spec.
```
		// RecordTypes are required, so discard records that don't have them.
		if elem.Type == nil || (*elem.Type != *ko.Spec.RecordType) {
			continue
		}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
