### PR TITLE
Add `recordType` additional key to `recordSet` resource identifier

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-08-06T02:38:07Z"
-  build_hash: 587b90dc860e91ee9a763e9e3bc4d3f1b2fbddb7
+  build_date: "2024-08-15T06:35:26Z"
+  build_hash: 959eaa58cf17d1fd3ce540bf4e9b4184d08f65b5
   go_version: go1.22.5
-  version: v0.36.0
+  version: v0.36.0-6-g959eaa5
 api_directory_checksum: 78fb7fd24a85da24b8de6246cad67ff3fb6598f8
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 5683838da0708bf6df32d169894722b65746bb1d
+  file_checksum: 3a694e7177f90f7ba4c526b14e1ce2b1e9748446
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -139,6 +139,8 @@ resources:
         template_path: hooks/record_set/sdk_read_many_pre_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/record_set/sdk_read_many_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/record_set/post_set_resource_identifiers.go.tpl
     list_operation:
       match_fields:
       - HostedZoneId

--- a/generator.yaml
+++ b/generator.yaml
@@ -139,6 +139,8 @@ resources:
         template_path: hooks/record_set/sdk_read_many_pre_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/record_set/sdk_read_many_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/record_set/post_set_resource_identifiers.go.tpl
     list_operation:
       match_fields:
       - HostedZoneId

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -157,6 +157,5 @@ leaderElection:
 # Configuration for feature gates.  These are optional controller features that
 # can be individually enabled ("true") or disabled ("false") by adding key/value
 # pairs below.
-featureGates: {}
-  # featureGate1: true
-  # featureGate2: false
+featureGates:
+  CARMv2: false

--- a/pkg/resource/record_set/resource.go
+++ b/pkg/resource/record_set/resource.go
@@ -95,6 +95,10 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 		r.ko.Spec.HostedZoneID = &f0
 	}
 
+	f1, f1ok := identifier.AdditionalKeys["recordType"]
+	if f1ok {
+		r.ko.Spec.RecordType = &f1
+	}
 	return nil
 }
 

--- a/templates/hooks/record_set/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/record_set/post_set_resource_identifiers.go.tpl
@@ -1,0 +1,4 @@
+	f1, f1ok := identifier.AdditionalKeys["recordType"]
+	if f1ok {
+		r.ko.Spec.RecordType = &f1
+	}


### PR DESCRIPTION
Issue [#2108](https://github.com/aws-controllers-k8s/community/issues/2108)

Description of changes:
* Added `post_set_resource_identifiers` hook template
* Regenerated controller


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
