### PR TITLE
remove getImmutableFieldChanges references

### DIFF
--- a/pkg/resource/health_check/hooks.go
+++ b/pkg/resource/health_check/hooks.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	svcapitypes "github.com/aws-controllers-k8s/route53-controller/apis/v1alpha1"
@@ -34,12 +33,6 @@ func (rm *resourceManager) customUpdateHealthCheck(
 	defer func() {
 		exit(err)
 	}()
-
-	// Do not proceed with update if an immutable field was updated
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function

--- a/pkg/resource/record_set/hooks.go
+++ b/pkg/resource/record_set/hooks.go
@@ -3,7 +3,6 @@ package record_set
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	svcapitypes "github.com/aws-controllers-k8s/route53-controller/apis/v1alpha1"
@@ -187,12 +186,6 @@ func (rm *resourceManager) customUpdateRecordSet(
 	defer func() {
 		exit(err)
 	}()
-
-	// Do not proceed with update if an immutable field was updated
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function


### PR DESCRIPTION
fix https://github.com/aws-controllers-k8s/code-generator/pull/565

Description of changes:
Remove getImmutableFieldChanges from hooks to support cel immutability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
