### PR TITLE
chore: Add DelegationSet to Status for HostedZone

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-02-20T18:21:43Z"
+  build_date: "2025-02-28T11:25:20Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
   go_version: go1.24.0
   version: v0.43.2
-api_directory_checksum: 0e842f9492e354f790fd6f70698b57776324fc31
+api_directory_checksum: b920521646bacef1fba9d0b97a423d11565c7a60
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: af1e20f94f0b1e81627c90fa1b82bf77ff994e48
+  file_checksum: 262cace7fe285ca8833a0f656963c0f5872b0404
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-02-28T11:25:20Z"
+  build_date: "2025-02-28T23:26:32Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
   go_version: go1.24.0
   version: v0.43.2

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-02-28T23:26:32Z"
+  build_date: "2025-03-03T23:36:46Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
   go_version: go1.24.0
   version: v0.43.2

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -163,6 +163,11 @@ resources:
       - InvalidInput
       - InvalidVPCId
     fields:
+      DelegationSet:
+        from:
+          operation: CreateHostedZone
+          path: DelegationSet
+        is_read_only: true
       Tags:
         from:
           operation: ChangeTagsForResource

--- a/apis/v1alpha1/hosted_zone.go
+++ b/apis/v1alpha1/hosted_zone.go
@@ -96,6 +96,9 @@ type HostedZoneStatus struct {
 	// and Comment elements don't appear in the response.
 	// +kubebuilder:validation:Optional
 	Config *HostedZoneConfig `json:"config,omitempty"`
+	// A complex type that describes the name servers for this hosted zone.
+	// +kubebuilder:validation:Optional
+	DelegationSet *DelegationSet `json:"delegationSet,omitempty"`
 	// The ID that Amazon Route 53 assigned to the hosted zone when you created
 	// it.
 	// +kubebuilder:validation:Optional

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -903,6 +903,11 @@ func (in *HostedZoneStatus) DeepCopyInto(out *HostedZoneStatus) {
 		*out = new(HostedZoneConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DelegationSet != nil {
+		in, out := &in.DelegationSet, &out.DelegationSet
+		*out = new(DelegationSet)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ID != nil {
 		in, out := &in.ID, &out.ID
 		*out = new(string)

--- a/config/crd/bases/route53.services.k8s.aws_hostedzones.yaml
+++ b/config/crd/bases/route53.services.k8s.aws_hostedzones.yaml
@@ -205,6 +205,19 @@ spec:
                   privateZone:
                     type: boolean
                 type: object
+              delegationSet:
+                description: A complex type that describes the name servers for this
+                  hosted zone.
+                properties:
+                  callerReference:
+                    type: string
+                  id:
+                    type: string
+                  nameServers:
+                    items:
+                      type: string
+                    type: array
+                type: object
               id:
                 description: |-
                   The ID that Amazon Route 53 assigned to the hosted zone when you created

--- a/generator.yaml
+++ b/generator.yaml
@@ -163,6 +163,11 @@ resources:
       - InvalidInput
       - InvalidVPCId
     fields:
+      DelegationSet:
+        from:
+          operation: CreateHostedZone
+          path: DelegationSet
+        is_read_only: true
       Tags:
         from:
           operation: ChangeTagsForResource

--- a/helm/crds/route53.services.k8s.aws_hostedzones.yaml
+++ b/helm/crds/route53.services.k8s.aws_hostedzones.yaml
@@ -205,6 +205,19 @@ spec:
                   privateZone:
                     type: boolean
                 type: object
+              delegationSet:
+                description: A complex type that describes the name servers for this
+                  hosted zone.
+                properties:
+                  callerReference:
+                    type: string
+                  id:
+                    type: string
+                  nameServers:
+                    items:
+                      type: string
+                    type: array
+                type: object
               id:
                 description: |-
                   The ID that Amazon Route 53 assigned to the hosted zone when you created

--- a/pkg/resource/hosted_zone/sdk.go
+++ b/pkg/resource/hosted_zone/sdk.go
@@ -137,6 +137,22 @@ func (rm *resourceManager) sdkFind(
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
 		return nil, err
 	}
+
+	if resp.DelegationSet != nil {
+		f := &svcapitypes.DelegationSet{}
+		if resp.DelegationSet.CallerReference != nil {
+			f.CallerReference = resp.DelegationSet.CallerReference
+		}
+		if resp.DelegationSet.Id != nil {
+			f.ID = resp.DelegationSet.Id
+		}
+		if resp.DelegationSet.NameServers != nil {
+			f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
+		}
+		ko.Status.DelegationSet = f
+	} else {
+		ko.Status.DelegationSet = nil
+	}
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/hosted_zone/sdk.go
+++ b/pkg/resource/hosted_zone/sdk.go
@@ -247,6 +247,22 @@ func (rm *resourceManager) sdkCreate(
 		latest.ko = &svcapitypes.HostedZone{}
 		latest.ko.Status.ID = ko.Status.ID
 
+		if resp.DelegationSet != nil {
+			f := &svcapitypes.DelegationSet{}
+			if resp.DelegationSet.CallerReference != nil {
+				f.CallerReference = resp.DelegationSet.CallerReference
+			}
+			if resp.DelegationSet.Id != nil {
+				f.ID = resp.DelegationSet.Id
+			}
+			if resp.DelegationSet.NameServers != nil {
+				f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
+			}
+			ko.Status.DelegationSet = f
+		} else {
+			ko.Status.DelegationSet = nil
+		}
+
 		// This is create operation. So, no tags are present in HostedZone.
 		// So, 'latest' is empty except we have copied 'ID' into the status to
 		// make syncTags() happy.

--- a/pkg/resource/hosted_zone/sdk.go
+++ b/pkg/resource/hosted_zone/sdk.go
@@ -140,12 +140,6 @@ func (rm *resourceManager) sdkFind(
 
 	if resp.DelegationSet != nil {
 		f := &svcapitypes.DelegationSet{}
-		if resp.DelegationSet.CallerReference != nil {
-			f.CallerReference = resp.DelegationSet.CallerReference
-		}
-		if resp.DelegationSet.Id != nil {
-			f.ID = resp.DelegationSet.Id
-		}
 		if resp.DelegationSet.NameServers != nil {
 			f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
 		}
@@ -153,6 +147,7 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Status.DelegationSet = nil
 	}
+
 	return &resource{ko}, nil
 }
 
@@ -265,12 +260,6 @@ func (rm *resourceManager) sdkCreate(
 
 		if resp.DelegationSet != nil {
 			f := &svcapitypes.DelegationSet{}
-			if resp.DelegationSet.CallerReference != nil {
-				f.CallerReference = resp.DelegationSet.CallerReference
-			}
-			if resp.DelegationSet.Id != nil {
-				f.ID = resp.DelegationSet.Id
-			}
 			if resp.DelegationSet.NameServers != nil {
 				f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
 			}

--- a/templates/hooks/hosted_zone/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/hosted_zone/sdk_create_post_set_output.go.tpl
@@ -3,6 +3,22 @@
 		latest.ko = &svcapitypes.HostedZone{}
 		latest.ko.Status.ID = ko.Status.ID
 
+		if resp.DelegationSet != nil {
+			f := &svcapitypes.DelegationSet{}
+			if resp.DelegationSet.CallerReference != nil {
+				f.CallerReference = resp.DelegationSet.CallerReference
+			}
+			if resp.DelegationSet.Id != nil {
+				f.ID = resp.DelegationSet.Id
+			}
+			if resp.DelegationSet.NameServers != nil {
+				f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
+			}
+			ko.Status.DelegationSet = f
+		} else {
+			ko.Status.DelegationSet = nil
+		}
+
 		// This is create operation. So, no tags are present in HostedZone.
 		// So, 'latest' is empty except we have copied 'ID' into the status to
 		// make syncTags() happy.

--- a/templates/hooks/hosted_zone/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/hosted_zone/sdk_create_post_set_output.go.tpl
@@ -5,12 +5,6 @@
 
 		if resp.DelegationSet != nil {
 			f := &svcapitypes.DelegationSet{}
-			if resp.DelegationSet.CallerReference != nil {
-				f.CallerReference = resp.DelegationSet.CallerReference
-			}
-			if resp.DelegationSet.Id != nil {
-				f.ID = resp.DelegationSet.Id
-			}
 			if resp.DelegationSet.NameServers != nil {
 				f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
 			}

--- a/templates/hooks/hosted_zone/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/hosted_zone/sdk_read_one_post_set_output.go.tpl
@@ -1,3 +1,19 @@
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
 		return nil, err
 	}
+
+	if resp.DelegationSet != nil {
+		f := &svcapitypes.DelegationSet{}
+		if resp.DelegationSet.CallerReference != nil {
+			f.CallerReference = resp.DelegationSet.CallerReference
+		}
+		if resp.DelegationSet.Id != nil {
+			f.ID = resp.DelegationSet.Id
+		}
+		if resp.DelegationSet.NameServers != nil {
+			f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
+		}
+		ko.Status.DelegationSet = f
+	} else {
+		ko.Status.DelegationSet = nil
+	}

--- a/templates/hooks/hosted_zone/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/hosted_zone/sdk_read_one_post_set_output.go.tpl
@@ -4,12 +4,6 @@
 
 	if resp.DelegationSet != nil {
 		f := &svcapitypes.DelegationSet{}
-		if resp.DelegationSet.CallerReference != nil {
-			f.CallerReference = resp.DelegationSet.CallerReference
-		}
-		if resp.DelegationSet.Id != nil {
-			f.ID = resp.DelegationSet.Id
-		}
 		if resp.DelegationSet.NameServers != nil {
 			f.NameServers = aws.StringSlice(resp.DelegationSet.NameServers)
 		}

--- a/test/e2e/tests/test_hosted_zone.py
+++ b/test/e2e/tests/test_hosted_zone.py
@@ -112,12 +112,13 @@ class TestHostedZone:
     def test_delegation_set(self, route53_client, public_hosted_zone):
         ref, cr = public_hosted_zone
 
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
         resource = k8s.get_resource(ref)
         resource_id = cr["status"]["id"]
 
         assert resource_id
 
-        time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check hosted_zone exists in AWS
         route53_validator = Route53Validator(route53_client)

--- a/test/e2e/tests/test_hosted_zone.py
+++ b/test/e2e/tests/test_hosted_zone.py
@@ -115,6 +115,8 @@ class TestHostedZone:
         resource = k8s.get_resource(ref)
         resource_id = cr["status"]["id"]
 
+        assert resource_id
+
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check hosted_zone exists in AWS

--- a/test/e2e/tests/test_hosted_zone.py
+++ b/test/e2e/tests/test_hosted_zone.py
@@ -124,9 +124,7 @@ class TestHostedZone:
         route53_validator = Route53Validator(route53_client)
         route53_validator.assert_hosted_zone(resource_id)
 
-        assert resource["status"]["callerReference"]
         assert resource["status"]["delegationSet"] is not None
-        assert resource["status"]["delegationSet"]["id"]
         assert len(resource["status"]["delegationSet"]["nameServers"]) > 0
 
     @pytest.mark.resource_data({'tag_key': 'initialtagkey', 'tag_value': 'initialtagvalue'})

--- a/test/e2e/tests/test_hosted_zone.py
+++ b/test/e2e/tests/test_hosted_zone.py
@@ -124,8 +124,8 @@ class TestHostedZone:
         route53_validator = Route53Validator(route53_client)
         route53_validator.assert_hosted_zone(resource_id)
 
+        assert resource["status"]["callerReference"]
         assert resource["status"]["delegationSet"] is not None
-        assert resource["status"]["delegationSet"]["callerReference"]
         assert resource["status"]["delegationSet"]["id"]
         assert len(resource["status"]["delegationSet"]["nameServers"]) > 0
 

--- a/test/e2e/tests/test_hosted_zone.py
+++ b/test/e2e/tests/test_hosted_zone.py
@@ -109,6 +109,23 @@ class TestHostedZone:
         route53_validator = Route53Validator(route53_client)
         route53_validator.assert_hosted_zone(zone_id)
 
+    def test_delegation_set(self, route53_client, public_hosted_zone):
+        ref, cr = public_hosted_zone
+
+        resource = k8s.get_resource(ref)
+        resource_id = cr["status"]["id"]
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        # Check hosted_zone exists in AWS
+        route53_validator = Route53Validator(route53_client)
+        route53_validator.assert_hosted_zone(resource_id)
+
+        assert resource["status"]["delegationSet"] is not None
+        assert resource["status"]["delegationSet"]["callerReference"]
+        assert resource["status"]["delegationSet"]["id"]
+        assert len(resource["status"]["delegationSet"]["nameServers"]) > 0
+
     @pytest.mark.resource_data({'tag_key': 'initialtagkey', 'tag_value': 'initialtagvalue'})
     def test_crud_tags(self, route53_client, public_hosted_zone):
         ref, cr = public_hosted_zone

--- a/test/e2e/tests/test_hosted_zone.py
+++ b/test/e2e/tests/test_hosted_zone.py
@@ -108,7 +108,7 @@ class TestHostedZone:
         # Check hosted_zone exists in AWS
         route53_validator = Route53Validator(route53_client)
         route53_validator.assert_hosted_zone(zone_id)
-
+    @pytest.mark.resource_data({'tag_key': 'key', 'tag_value': 'value'})
     def test_delegation_set(self, route53_client, public_hosted_zone):
         ref, cr = public_hosted_zone
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2364

Description of changes:

Add the DelegationSet to the Status of HostedZone resources so the nameservers can be retrieved to then be referenced in a RecordSet for a different HostedZone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I'm not sure if there's a more proper way to get the sdkCreate and sdkFind calls to be generated with the relevant logic without the hook but I couldn't find a way to get that to happen. As such I've gone down the hook path.
