### PR TITLE
fix: populate recordSetName during adoption

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-05-02T16:51:49Z"
-  build_hash: f8dc5330705b3752ce07dce0ac831161fd4cb14f
-  go_version: go1.24.2
-  version: v0.45.0
+  build_date: "2025-05-07T20:10:24Z"
+  build_hash: a82538df1333319f8ec1d603f6cf293aefc46e1b
+  go_version: go1.24.1
+  version: v0.45.0-3-ga82538d
 api_directory_checksum: b920521646bacef1fba9d0b97a423d11565c7a60
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
         - "$(ACK_WATCH_NAMESPACE)"
         - --watch-selectors
         - "$(ACK_WATCH_SELECTORS)"
+        - --reconcile-resources
+        - "$(RECONCILE_RESOURCES)"
         - --deletion-policy
         - "$(DELETION_POLICY)"
 {{- if .Values.leaderElection.enabled }}
@@ -107,6 +109,8 @@ spec:
           value: {{ include "ack-route53-controller.watch-namespace" . }}
         - name: ACK_WATCH_SELECTORS
           value: {{ .Values.watchSelectors }}
+        - name: RECONCILE_RESOURCES
+          value: {{ join "," .Values.reconcile.resources | quote }}
         - name: DELETION_POLICY
           value: {{ .Values.deletionPolicy }}
         - name: LEADER_ELECTION_NAMESPACE

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -239,6 +239,14 @@
         },
         "resourceMaxConcurrentSyncs": {
           "type": "object"
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of resource kinds to reconcile. If empty, all resources will be reconciled.",
+          "default": []
         }
       },
       "type": "object"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -137,6 +137,14 @@ reconcile:
   # An object representing the reconcile max concurrent syncs configuration for each specific
   # resource.
   resourceMaxConcurrentSyncs: {}
+  
+  # Set the value of resources to specify which resource kinds to reconcile.
+  # If empty, all resources will be reconciled.
+  # If specified, only the listed resource kinds will be reconciled.
+  resources:
+    - Healthchecks
+    - Hostedzones
+    - Recordsets
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/pkg/resource/record_set/resource.go
+++ b/pkg/resource/record_set/resource.go
@@ -102,6 +102,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	if f1ok {
 		r.ko.Spec.RecordType = &f1
 	}
+
+	if f2, f2ok := identifier.AdditionalKeys["name"]; f2ok {
+		r.ko.Spec.Name = &f2
+	}
+
 	return nil
 }
 
@@ -120,6 +125,10 @@ func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) erro
 
 	if f1, f1ok := fields["recordType"]; f1ok {
 		r.ko.Spec.RecordType = &f1
+	}
+
+	if f2, f2ok := fields["name"]; f2ok {
+		r.ko.Spec.Name = &f2
 	}
 
 	return nil

--- a/templates/hooks/record_set/post_populate_resource_from_annotation.go.tpl
+++ b/templates/hooks/record_set/post_populate_resource_from_annotation.go.tpl
@@ -1,3 +1,7 @@
 	if f1, f1ok := fields["recordType"]; f1ok {
 		r.ko.Spec.RecordType = &f1
-	} 
+	}
+
+	if f2, f2ok := fields["name"]; f2ok {
+		r.ko.Spec.Name = &f2
+	}

--- a/templates/hooks/record_set/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/record_set/post_set_resource_identifiers.go.tpl
@@ -2,3 +2,7 @@
 	if f1ok {
 		r.ko.Spec.RecordType = &f1
 	}
+
+	if f2, f2ok := identifier.AdditionalKeys["name"]; f2ok {
+		r.ko.Spec.Name = &f2
+	}


### PR DESCRIPTION
Issue [#2187](https://github.com/aws-controllers-k8s/community/issues/2187)

Description of changes:
Currently the recordSetName does not get populated to the 
resource manifest, which makes it impossible for user to be 
able to adopt recordSets with certain types.

Tested these changes locally when adopting CNAME recordType

Here's how you would adopt a resource now:
```yaml
apiVersion: route53.services.k8s.aws/v1alpha1
kind: RecordSet
metadata:
  name: myrecordSet
  annotations:
    services.k8s.aws/deletion-policy: retain
    services.k8s.aws/adoption-policy: adopt
    services.k8s.aws/adoption-fields: |
      {
        "id": "<RecordSet ID>",
        "hostedZoneID": "<hostedZoneID>",
        "recordType": "CNAME",
        "name": "<RecordSetName>"
      }
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
