### PR TITLE
Fix recordset adoption sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *~
 .idea
+.vscode
 /docs/site
 bin
 build

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:19:29Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  build_date: "2026-05-06T22:44:37Z"
+  build_hash: ece451c52fa72a9f7cfca3b086b8a4729b592ae4
   go_version: go1.26.2
-  version: v0.58.1
+  version: v0.58.1-4-gece451c
 api_directory_checksum: 713280fd387d69f81ea25512b25bf84dfa09017d
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/record_set/sdk.go
+++ b/pkg/resource/record_set/sdk.go
@@ -283,12 +283,19 @@ func (rm *resourceManager) sdkFind(
 	// Status represents whether record changes have been fully propagated to all
 	// Route 53 authoritative DNS servers. The current status for the propagation
 	// should be updated if it's not already INSYNC.
-	err = rm.syncStatus(ctx, ko)
-	if err != nil {
-		return nil, err
-	}
-	if ko.Status.Status == nil || svcsdktypes.ChangeStatus(*ko.Status.Status) != svcsdktypes.ChangeStatusInsync {
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	//
+	// If there is no change ID (e.g. the resource was adopted rather than
+	// created/updated by this controller), we skip the propagation check.
+	// The record was confirmed to exist via ListResourceRecordSets, so it is
+	// already present on the authoritative servers.
+	if ko.Status.ID != nil {
+		err = rm.syncStatus(ctx, ko)
+		if err != nil {
+			return nil, err
+		}
+		if ko.Status.Status == nil || svcsdktypes.ChangeStatus(*ko.Status.Status) != svcsdktypes.ChangeStatusInsync {
+			ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		}
 	}
 
 	return &resource{ko}, nil

--- a/templates/hooks/record_set/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/record_set/sdk_read_many_post_set_output.go.tpl
@@ -2,10 +2,17 @@
 	// Status represents whether record changes have been fully propagated to all
 	// Route 53 authoritative DNS servers. The current status for the propagation
 	// should be updated if it's not already INSYNC.
-	err = rm.syncStatus(ctx, ko)
-	if err != nil {
-		return nil, err
-	}
-	if ko.Status.Status == nil || svcsdktypes.ChangeStatus(*ko.Status.Status) != svcsdktypes.ChangeStatusInsync {
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	//
+	// If there is no change ID (e.g. the resource was adopted rather than
+	// created/updated by this controller), we skip the propagation check.
+	// The record was confirmed to exist via ListResourceRecordSets, so it is
+	// already present on the authoritative servers.
+	if ko.Status.ID != nil {
+		err = rm.syncStatus(ctx, ko)
+		if err != nil {
+			return nil, err
+		}
+		if ko.Status.Status == nil || svcsdktypes.ChangeStatus(*ko.Status.Status) != svcsdktypes.ChangeStatusInsync {
+			ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		}
 	}

--- a/test/e2e/resources/record_set_adopt.yaml
+++ b/test/e2e/resources/record_set_adopt.yaml
@@ -1,0 +1,13 @@
+apiVersion: route53.services.k8s.aws/v1alpha1
+kind: RecordSet
+metadata:
+  name: $ADOPT_RECORD_NAME
+  annotations:
+    services.k8s.aws/adoption-policy: adopt-or-create
+spec:
+  name: $ADOPT_RECORD_DNS_NAME
+  hostedZoneID: $HOSTED_ZONE_ID
+  recordType: A
+  resourceRecords:
+  - value: $IP_ADDR
+  ttl: 300

--- a/test/e2e/tests/test_record_set.py
+++ b/test/e2e/tests/test_record_set.py
@@ -20,8 +20,9 @@ import socket
 import struct
 import time
 
+from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
-from e2e import service_marker, get_route53_resource, create_route53_resource, delete_route53_resource, patch_route53_resource
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, get_route53_resource, create_route53_resource, delete_route53_resource, patch_route53_resource, load_eks_resource
 from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.tests.helper import Route53Validator
@@ -173,3 +174,91 @@ class TestRecordSet:
 
         # Ensure that the status eventually switches from PENDING to INSYNC
         assert verify_status_insync(ref) is True
+
+
+    def test_adopted_record_set_reaches_synced_state(self, route53_client, private_hosted_zone):
+        """Test that adopting an existing RecordSet reaches ACK.ResourceSynced: True.
+
+        This validates the fix for https://github.com/aws-controllers-k8s/community/issues/2861
+        where adopted RecordSets would get stuck with ACK.ResourceSynced: False because
+        no ChangeInfo.Id is set during adoption (no create/update is performed).
+        """
+        zone_id, domain = private_hosted_zone
+        parsed_zone_id = zone_id.split("/")[-1]
+        ip_address = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
+        record_dns_name = "adopt-test"
+        full_dns_name = f"{record_dns_name}.{domain}"
+
+        # Create the record set directly in AWS via boto3 (simulating a pre-existing resource)
+        route53_client.change_resource_record_sets(
+            HostedZoneId=parsed_zone_id,
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": "CREATE",
+                        "ResourceRecordSet": {
+                            "Name": full_dns_name,
+                            "Type": "A",
+                            "TTL": 300,
+                            "ResourceRecords": [{"Value": ip_address}],
+                        },
+                    }
+                ]
+            },
+        )
+
+        ref = None
+        try:
+            # Now adopt the record set via ACK
+            adopt_record_name = random_suffix_name("adopt-record", 32)
+            replacements = REPLACEMENT_VALUES.copy()
+            replacements["ADOPT_RECORD_NAME"] = adopt_record_name
+            replacements["ADOPT_RECORD_DNS_NAME"] = record_dns_name
+            replacements["HOSTED_ZONE_ID"] = parsed_zone_id
+            replacements["IP_ADDR"] = ip_address
+
+            resource_data = load_eks_resource(
+                "record_set_adopt",
+                additional_replacements=replacements,
+            )
+
+            ref = k8s.CustomResourceReference(
+                CRD_GROUP, CRD_VERSION, "recordsets",
+                adopt_record_name, namespace="default",
+            )
+            k8s.create_custom_resource(ref, resource_data)
+            cr = k8s.wait_resource_consumed_by_controller(ref)
+            assert cr is not None
+
+            # The adopted resource should reach a synced state without a change ID
+            assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+            # Verify no change ID was set (adoption doesn't trigger create/update)
+            record = get_route53_resource(ref)
+            assert record["status"].get("id") is None
+        finally:
+            # Clean up the K8s resource if it was created
+            if ref is not None:
+                delete_route53_resource(ref)
+
+            # Ensure the AWS record is removed even if the K8s delete fails
+            try:
+                route53_client.change_resource_record_sets(
+                    HostedZoneId=parsed_zone_id,
+                    ChangeBatch={
+                        "Changes": [
+                            {
+                                "Action": "DELETE",
+                                "ResourceRecordSet": {
+                                    "Name": full_dns_name,
+                                    "Type": "A",
+                                    "TTL": 300,
+                                    "ResourceRecords": [{"Value": ip_address}],
+                                },
+                            }
+                        ]
+                    },
+                )
+            except route53_client.exceptions.InvalidChangeBatch:
+                # Record already deleted by the controller
+                pass


### PR DESCRIPTION
Issue #, if available: [2861](https://github.com/aws-controllers-k8s/community/issues/2861)

Description of changes:
When a RecordSet is adopted with `adopt-or-create` and there is no delta between the desired state and the already present AWS resource the adopted RecordSet fails to enter synced state as there is no Change ID to evaluate. This PR fixes this issue by no longer forcing the resource to Synced false in `sdkFind` when no Change ID is present in the resource status. Pending Change batches will still be forced to a Synced false condition and in cases where an update failed drift remediation should still detect a delta and re-attempt the update.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
