### PR TITLE
fix: mark HostedZone Name, DelegationSetID, and PrivateZone as immutable

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:46:59Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
+  build_date: "2026-06-03T18:00:56Z"
+  build_hash: b26b7d212548d15b7add7e7fee44052449457e85
   go_version: go1.26.3
-  version: v0.59.1
-api_directory_checksum: 713280fd387d69f81ea25512b25bf84dfa09017d
+  version: v0.59.1-5-gb26b7d2
+api_directory_checksum: a97d3981281b467fa9886c520598e2eea74ee0e2
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 5c436d09c98a7ffde5437fc6120b3b4f7ea7c120
+  file_checksum: 8d479ac1a7156f041200261ed36820337f30b494
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -163,6 +163,12 @@ resources:
       - InvalidInput
       - InvalidVPCId
     fields:
+      Name:
+        is_immutable: true
+      DelegationSetID:
+        is_immutable: true
+      HostedZoneConfig.PrivateZone:
+        is_immutable: true
       VPCs:
         custom_field:
           list_of: VPC

--- a/apis/v1alpha1/hosted_zone.go
+++ b/apis/v1alpha1/hosted_zone.go
@@ -34,6 +34,7 @@ type HostedZoneSpec struct {
 	// for a subdomain, make sure that the parent hosted zone doesn't use one or
 	// more of the same name servers. If you have overlapping nameservers, the operation
 	// will cause a ConflictingDomainsExist error.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	DelegationSetID *string `json:"delegationSetID,omitempty"`
 	// (Optional) A complex type that contains the following optional values:
 	//
@@ -53,6 +54,7 @@ type HostedZoneSpec struct {
 	// with your DNS registrar. If your domain name is registered with a registrar
 	// other than Route 53, change the name servers for your domain to the set of
 	// NameServers that CreateHostedZone returns in DelegationSet.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
 	// A complex type that contains a list of the tags that you want to add to the

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -187,8 +187,9 @@ type HealthCheck_SDK struct {
 // If you don't want to specify a comment, omit both the HostedZoneConfig and
 // Comment elements.
 type HostedZoneConfig struct {
-	Comment     *string `json:"comment,omitempty"`
-	PrivateZone *bool   `json:"privateZone,omitempty"`
+	Comment *string `json:"comment,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
+	PrivateZone *bool `json:"privateZone,omitempty"`
 }
 
 // In the response to a ListHostedZonesByVPC request, the HostedZoneSummaries

--- a/config/crd/bases/route53.services.k8s.aws_hostedzones.yaml
+++ b/config/crd/bases/route53.services.k8s.aws_hostedzones.yaml
@@ -54,6 +54,9 @@ spec:
                   more of the same name servers. If you have overlapping nameservers, the operation
                   will cause a ConflictingDomainsExist error.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               hostedZoneConfig:
                 description: |-
                   (Optional) A complex type that contains the following optional values:
@@ -69,6 +72,9 @@ spec:
                     type: string
                   privateZone:
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: Value is immutable once set
+                      rule: self == oldSelf
                 type: object
               name:
                 description: |-
@@ -82,6 +88,9 @@ spec:
                   other than Route 53, change the name servers for your domain to the set of
                   NameServers that CreateHostedZone returns in DelegationSet.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               tags:
                 description: |-
                   A complex type that contains a list of the tags that you want to add to the
@@ -236,6 +245,9 @@ spec:
                     type: string
                   privateZone:
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: Value is immutable once set
+                      rule: self == oldSelf
                 type: object
               delegationSet:
                 description: A complex type that describes the name servers for this

--- a/generator.yaml
+++ b/generator.yaml
@@ -163,6 +163,12 @@ resources:
       - InvalidInput
       - InvalidVPCId
     fields:
+      Name:
+        is_immutable: true
+      DelegationSetID:
+        is_immutable: true
+      HostedZoneConfig.PrivateZone:
+        is_immutable: true
       VPCs:
         custom_field:
           list_of: VPC

--- a/helm/crds/route53.services.k8s.aws_hostedzones.yaml
+++ b/helm/crds/route53.services.k8s.aws_hostedzones.yaml
@@ -54,6 +54,9 @@ spec:
                   more of the same name servers. If you have overlapping nameservers, the operation
                   will cause a ConflictingDomainsExist error.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               hostedZoneConfig:
                 description: |-
                   (Optional) A complex type that contains the following optional values:
@@ -69,6 +72,9 @@ spec:
                     type: string
                   privateZone:
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: Value is immutable once set
+                      rule: self == oldSelf
                 type: object
               name:
                 description: |-
@@ -82,6 +88,9 @@ spec:
                   other than Route 53, change the name servers for your domain to the set of
                   NameServers that CreateHostedZone returns in DelegationSet.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               tags:
                 description: |-
                   A complex type that contains a list of the tags that you want to add to the
@@ -236,6 +245,9 @@ spec:
                     type: string
                   privateZone:
                     type: boolean
+                    x-kubernetes-validations:
+                    - message: Value is immutable once set
+                      rule: self == oldSelf
                 type: object
               delegationSet:
                 description: A complex type that describes the name servers for this


### PR DESCRIPTION
Description of changes:
These fields cannot be changed after a hosted zone is created — the AWS
API has no mechanism to rename a zone, reassign its delegation set, or
convert between public and private. Marking them is_immutable adds
XValidation rules that reject mutations at the admission layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
