### PR TITLE
fix: correct RecordSet sdkFind false-positive for FQDN names

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-06-03T18:00:56Z"
-  build_hash: b26b7d212548d15b7add7e7fee44052449457e85
+  build_date: "2026-06-18T16:59:24Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
   go_version: go1.26.3
-  version: v0.59.1-5-gb26b7d2
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: a97d3981281b467fa9886c520598e2eea74ee0e2
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/record_set/sdk.go
+++ b/pkg/resource/record_set/sdk.go
@@ -122,7 +122,12 @@ func (rm *resourceManager) sdkFind(
 			isFQDN := r.ko.Spec.Name != nil && strings.HasSuffix(*r.ko.Spec.Name, ".")
 			var subdomain string
 			if isFQDN {
-				subdomain = *r.ko.Spec.Name
+				// Spec.Name is already fully-qualified (trailing dot), and so is
+				// the record's returned Name. Compare the record's actual name
+				// against Spec.Name - do NOT substitute Spec.Name here, or every
+				// returned record would falsely compare equal to Spec.Name and the
+				// equality check below would never filter out non-matching records.
+				subdomain = decodeRecordName(*elem.Name)
 			} else {
 				subdomain = strings.TrimSuffix(*elem.Name, domain)
 				subdomain = decodeRecordName(subdomain)

--- a/templates/hooks/record_set/sdk_read_many_pre_set_output.go.tpl
+++ b/templates/hooks/record_set/sdk_read_many_pre_set_output.go.tpl
@@ -13,7 +13,12 @@
 			isFQDN := r.ko.Spec.Name != nil && strings.HasSuffix(*r.ko.Spec.Name, ".")
 			var subdomain string
 			if isFQDN {
-				subdomain = *r.ko.Spec.Name
+				// Spec.Name is already fully-qualified (trailing dot), and so is
+				// the record's returned Name. Compare the record's actual name
+				// against Spec.Name - do NOT substitute Spec.Name here, or every
+				// returned record would falsely compare equal to Spec.Name and the
+				// equality check below would never filter out non-matching records.
+				subdomain = decodeRecordName(*elem.Name)
 			} else {
 				subdomain = strings.TrimSuffix(*elem.Name, domain)
 				subdomain = decodeRecordName(subdomain)

--- a/test/e2e/tests/test_record_set.py
+++ b/test/e2e/tests/test_record_set.py
@@ -176,6 +176,81 @@ class TestRecordSet:
         assert verify_status_insync(ref) is True
 
 
+    def test_fqdn_record_created_when_sibling_sorts_after(self, route53_client, private_hosted_zone):
+        zone_id, domain = private_hosted_zone
+        parsed_zone_id = zone_id.split("/")[-1]
+
+        sibling_dns_name = random_suffix_name("zzz-sibling", 32) + "." + domain
+        sibling_ip = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
+        new_ip = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
+
+        route53_client.change_resource_record_sets(
+            HostedZoneId=parsed_zone_id,
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": "CREATE",
+                        "ResourceRecordSet": {
+                            "Name": sibling_dns_name,
+                            "Type": "A",
+                            "TTL": 300,
+                            "ResourceRecords": [{"Value": sibling_ip}],
+                        },
+                    }
+                ]
+            },
+        )
+
+        ref = None
+        try:
+            k8s_name = random_suffix_name("aaa-fqdn", 32)
+            replacements = REPLACEMENT_VALUES.copy()
+            replacements["FQDN_K8S_NAME"] = k8s_name
+            replacements["FQDN_SPEC_NAME"] = k8s_name + "." + domain
+            replacements["HOSTED_ZONE_ID"] = parsed_zone_id
+            replacements["IP_ADDR"] = new_ip
+
+            resource_data = load_eks_resource(
+                "record_set_fqdn",
+                additional_replacements=replacements,
+            )
+
+            ref = k8s.CustomResourceReference(
+                CRD_GROUP, CRD_VERSION, "recordsets",
+                k8s_name, namespace="default",
+            )
+            k8s.create_custom_resource(ref, resource_data)
+            cr = k8s.wait_resource_consumed_by_controller(ref)
+            assert cr is not None
+
+            assert status_id_exists(ref) is True
+
+            route53_validator = Route53Validator(route53_client)
+            route53_validator.assert_record_set(get_route53_resource(ref), domain)
+        finally:
+            if ref is not None:
+                delete_route53_resource(ref)
+
+            try:
+                route53_client.change_resource_record_sets(
+                    HostedZoneId=parsed_zone_id,
+                    ChangeBatch={
+                        "Changes": [
+                            {
+                                "Action": "DELETE",
+                                "ResourceRecordSet": {
+                                    "Name": sibling_dns_name,
+                                    "Type": "A",
+                                    "TTL": 300,
+                                    "ResourceRecords": [{"Value": sibling_ip}],
+                                },
+                            }
+                        ]
+                    },
+                )
+            except route53_client.exceptions.InvalidChangeBatch:
+                pass
+
     def test_adopted_record_set_reaches_synced_state(self, route53_client, private_hosted_zone):
         """Test that adopting an existing RecordSet reaches ACK.ResourceSynced: True.
 


### PR DESCRIPTION
Description of changes:
The FQDN branch of sdk_read_many_pre_set_output overwrote every returned
record's Name with Spec.Name, so the later equality check could never
filter, falsely matching the first same-type record at/after the
alphabetical start position. Compare the record's actual returned name
(decoded) against Spec.Name instead.

Resolves aws-controllers-k8s/community#2929

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
