### PR TITLE
fix(RecordSet): normalize AliasTarget trailing dot and hostedzone prefix before delta comparison

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-07T21:50:27Z"
-  build_hash: 0a6b791fa10a6140d862be334a6891868ee588eb
-  go_version: go1.26.4
-  version: v0.61.0
+  build_date: "2026-07-23T04:11:52Z"
+  build_hash: ab6940f9c532e013d284f670e50b727102b4126d
+  go_version: go1.26.5
+  version: v0.61.0-2-gab6940f
 api_directory_checksum: a97d3981281b467fa9886c520598e2eea74ee0e2
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 8d479ac1a7156f041200261ed36820337f30b494
+  file_checksum: 17c9ecbf43817608a2f2ce150c0138c801f4301a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -131,6 +131,8 @@ resources:
           operation: ListResourceRecordSets
           path: ResourceRecordSets.Weight
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/record_set/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -131,6 +131,8 @@ resources:
           operation: ListResourceRecordSets
           path: ResourceRecordSets.Weight
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/record_set/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:

--- a/pkg/resource/record_set/delta.go
+++ b/pkg/resource/record_set/delta.go
@@ -41,6 +41,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AliasTarget, b.ko.Spec.AliasTarget) {
 		delta.Add("Spec.AliasTarget", a.ko.Spec.AliasTarget, b.ko.Spec.AliasTarget)

--- a/pkg/resource/record_set/hooks.go
+++ b/pkg/resource/record_set/hooks.go
@@ -338,3 +338,31 @@ func decodeRecordName(name string) string {
 	}
 	return name
 }
+
+// customPreCompare normalizes AliasTarget fields before the generated delta
+// comparison runs. AWS always returns AliasTarget.DNSName with a trailing dot
+// and AliasTarget.HostedZoneID with a "/hostedzone/" prefix; users typically
+// omit both. Without normalization, every reconcile produces a spurious delta
+// and triggers a perpetual update loop.
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if a.ko.Spec.AliasTarget != nil && a.ko.Spec.AliasTarget.DNSName != nil {
+		normalized := strings.TrimSuffix(*a.ko.Spec.AliasTarget.DNSName, ".")
+		a.ko.Spec.AliasTarget.DNSName = &normalized
+	}
+	if b.ko.Spec.AliasTarget != nil && b.ko.Spec.AliasTarget.DNSName != nil {
+		normalized := strings.TrimSuffix(*b.ko.Spec.AliasTarget.DNSName, ".")
+		b.ko.Spec.AliasTarget.DNSName = &normalized
+	}
+	if a.ko.Spec.AliasTarget != nil && a.ko.Spec.AliasTarget.HostedZoneID != nil {
+		normalized := strings.TrimPrefix(*a.ko.Spec.AliasTarget.HostedZoneID, "/hostedzone/")
+		a.ko.Spec.AliasTarget.HostedZoneID = &normalized
+	}
+	if b.ko.Spec.AliasTarget != nil && b.ko.Spec.AliasTarget.HostedZoneID != nil {
+		normalized := strings.TrimPrefix(*b.ko.Spec.AliasTarget.HostedZoneID, "/hostedzone/")
+		b.ko.Spec.AliasTarget.HostedZoneID = &normalized
+	}
+}

--- a/pkg/resource/record_set/hooks_test.go
+++ b/pkg/resource/record_set/hooks_test.go
@@ -2,6 +2,10 @@ package record_set
 
 import (
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	svcapitypes "github.com/aws-controllers-k8s/route53-controller/apis/v1alpha1"
 )
 
 func Test_getDNSName(t *testing.T) {
@@ -50,6 +54,131 @@ func Test_getDNSName(t *testing.T) {
 			got := rm.getDNSName(tt.recordName, tt.domain)
 			if got != tt.want {
 				t.Errorf("getDNSName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_customPreCompare(t *testing.T) {
+	tests := []struct {
+		testName     string
+		aAliasTarget *svcapitypes.AliasTarget
+		bAliasTarget *svcapitypes.AliasTarget
+		wantDeltaLen int
+	}{
+		{
+			testName: "DNSName with trailing dot on AWS side normalizes to no dot, no delta",
+			aAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			bAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			wantDeltaLen: 0,
+		},
+		{
+			testName: "DNSName without trailing dot on both sides, no delta",
+			aAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(true),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			bAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(true),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			wantDeltaLen: 0,
+		},
+		{
+			testName: "HostedZoneID with /hostedzone/ prefix normalizes, no delta",
+			aAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			bAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("/hostedzone/Z35SXDOTRQ7X7K"),
+			},
+			wantDeltaLen: 0,
+		},
+		{
+			testName: "HostedZoneID without prefix on both sides, no delta",
+			aAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			bAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			wantDeltaLen: 0,
+		},
+		{
+			testName: "Both DNSName trailing dot and HostedZoneID prefix need normalization, no delta",
+			aAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			bAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("/hostedzone/Z35SXDOTRQ7X7K"),
+			},
+			wantDeltaLen: 0,
+		},
+		{
+			testName:     "Nil AliasTarget on both sides, no panic, no delta",
+			aAliasTarget: nil,
+			bAliasTarget: nil,
+			wantDeltaLen: 0,
+		},
+		{
+			testName: "Genuinely different DNSName (not just formatting), delta IS present after normalization",
+			aAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("different-lb.elb.amazonaws.com"),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			bAliasTarget: &svcapitypes.AliasTarget{
+				DNSName:              aws.String("my-lb.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(false),
+				HostedZoneID:         aws.String("Z35SXDOTRQ7X7K"),
+			},
+			wantDeltaLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			a := &resource{ko: &svcapitypes.RecordSet{}}
+			b := &resource{ko: &svcapitypes.RecordSet{}}
+			a.ko.Spec.AliasTarget = tt.aAliasTarget
+			b.ko.Spec.AliasTarget = tt.bAliasTarget
+
+			// newResourceDelta internally calls customPreCompare before comparing fields
+			delta := newResourceDelta(a, b)
+
+			// Count only differences in AliasTarget fields
+			aliasTargetDiffs := 0
+			for _, diff := range delta.Differences {
+				if diff.Path.Contains("Spec.AliasTarget") {
+					aliasTargetDiffs++
+				}
+			}
+
+			if aliasTargetDiffs != tt.wantDeltaLen {
+				t.Errorf("Test %q: got %d AliasTarget differences, want %d. Differences: %v",
+					tt.testName, aliasTargetDiffs, tt.wantDeltaLen, delta.Differences)
 			}
 		})
 	}

--- a/test/e2e/resources/record_set_a_simple.yaml
+++ b/test/e2e/resources/record_set_a_simple.yaml
@@ -1,0 +1,11 @@
+apiVersion: route53.services.k8s.aws/v1alpha1
+kind: RecordSet
+metadata:
+  name: $BASE_RECORD_NAME
+spec:
+  name: $BASE_RECORD_DNS_NAME
+  hostedZoneID: $HOSTED_ZONE_ID
+  recordType: A
+  resourceRecords:
+  - value: $IP_ADDR
+  ttl: 300

--- a/test/e2e/resources/record_set_alias.yaml
+++ b/test/e2e/resources/record_set_alias.yaml
@@ -1,0 +1,12 @@
+apiVersion: route53.services.k8s.aws/v1alpha1
+kind: RecordSet
+metadata:
+  name: $ALIAS_RECORD_NAME
+spec:
+  name: $ALIAS_RECORD_DNS_NAME
+  hostedZoneID: $HOSTED_ZONE_ID
+  recordType: A
+  aliasTarget:
+    dnsName: $TARGET_DNS_NAME
+    hostedZoneID: $TARGET_HOSTED_ZONE_ID
+    evaluateTargetHealth: false

--- a/test/e2e/tests/test_record_set.py
+++ b/test/e2e/tests/test_record_set.py
@@ -18,6 +18,7 @@ import pytest
 import random
 import socket
 import struct
+import subprocess
 import time
 
 from acktest.k8s import resource as k8s
@@ -337,3 +338,130 @@ class TestRecordSet:
             except route53_client.exceptions.InvalidChangeBatch:
                 # Record already deleted by the controller
                 pass
+
+
+# Controller namespace and deployment name constants for log inspection
+ACK_NAMESPACE = "ack-route53-system"
+ACK_DEPLOYMENT = "ack-route53-controller-route53-chart"
+ACK_CONTROLLER_LABEL = "app.kubernetes.io/name=route53-chart"
+
+# Wait time for verifying no perpetual updates (seconds)
+ALIAS_IDLE_WAIT = 90
+# Maximum ChangeResourceRecordSets calls allowed after initial create when fix is applied
+FIX_MAX_CALLS = 1
+
+
+def _count_change_rrs_calls(since_seconds=120):
+    """Count ChangeResourceRecordSets log entries in the controller logs."""
+    cmd = [
+        "kubectl", "logs",
+        "-n", ACK_NAMESPACE,
+        "-l", ACK_CONTROLLER_LABEL,
+        f"--since={since_seconds}s",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.stdout.count("ChangeResourceRecordSets")
+
+
+@service_marker
+class TestRecordSetAlias:
+    """Tests that validate correct handling of alias record sets.
+
+    Regression test for the perpetual-update-loop bug where Route53 returns
+    AliasTarget.DNSName with a trailing dot and AliasTarget.HostedZoneID with
+    a /hostedzone/ prefix.  Without normalization the delta comparison always
+    detects a difference and calls ChangeResourceRecordSets on every reconcile.
+
+    With the fix (customPreCompare in hooks.go) both sides are normalised
+    before comparison so no spurious delta is found.
+    """
+
+    def test_alias_record_no_perpetual_updates(self, route53_client, private_hosted_zone):
+        """Verify that an alias A record does not trigger repeated ChangeResourceRecordSets
+        calls after the initial create.
+
+        Steps
+        -----
+        1. Create a base A record (the alias target).
+        2. Create an alias A record pointing to the base record.
+           The spec uses the zone ID WITHOUT the /hostedzone/ prefix and the
+           DNS name WITHOUT a trailing dot, exactly as a user would write it.
+        3. After both resources reach Synced=True, wait ALIAS_IDLE_WAIT seconds.
+        4. Count ChangeResourceRecordSets calls in that window.
+           With the fix there must be at most FIX_MAX_CALLS (the initial create).
+        5. Clean up both records.
+        """
+        zone_id, domain = private_hosted_zone
+        parsed_zone_id = zone_id.split("/")[-1]
+
+        base_record_name = random_suffix_name("alias-base", 32)
+        alias_record_name = random_suffix_name("alias-target", 32)
+
+        base_ref = None
+        alias_ref = None
+
+        try:
+            # Step 1: create a base A record that the alias will point to
+            base_replacements = REPLACEMENT_VALUES.copy()
+            base_replacements["BASE_RECORD_NAME"] = base_record_name
+            base_replacements["BASE_RECORD_DNS_NAME"] = base_record_name
+            base_replacements["HOSTED_ZONE_ID"] = parsed_zone_id
+            base_replacements["IP_ADDR"] = "1.2.3.4"
+
+            base_ref, base_cr = create_route53_resource(
+                "recordsets",
+                base_record_name,
+                "record_set_a_simple",
+                base_replacements,
+            )
+
+            assert k8s.wait_on_condition(base_ref, "ACK.ResourceSynced", "True", wait_periods=10), \
+                "Base A record did not reach ACK.ResourceSynced=True"
+
+            # Construct the alias target DNS name as a user would: no trailing dot
+            # domain already contains the trailing dot (e.g. "zone.ack.example.com.")
+            zone_domain = domain.rstrip(".")
+            alias_dns_target = f"{base_record_name}.{zone_domain}"
+
+            # Step 2: create the alias record pointing to the base record
+            # hostedZoneID and dnsName are specified WITHOUT /hostedzone/ prefix / trailing dot
+            alias_replacements = REPLACEMENT_VALUES.copy()
+            alias_replacements["ALIAS_RECORD_NAME"] = alias_record_name
+            alias_replacements["ALIAS_RECORD_DNS_NAME"] = alias_record_name
+            alias_replacements["HOSTED_ZONE_ID"] = parsed_zone_id
+            alias_replacements["TARGET_DNS_NAME"] = alias_dns_target
+            alias_replacements["TARGET_HOSTED_ZONE_ID"] = parsed_zone_id
+
+            alias_ref, alias_cr = create_route53_resource(
+                "recordsets",
+                alias_record_name,
+                "record_set_alias",
+                alias_replacements,
+            )
+
+            assert k8s.wait_on_condition(alias_ref, "ACK.ResourceSynced", "True", wait_periods=10), \
+                "Alias A record did not reach ACK.ResourceSynced=True"
+
+            # Step 3: wait to observe whether spurious updates are triggered
+            time.sleep(ALIAS_IDLE_WAIT)
+
+            # Step 4: count ChangeResourceRecordSets calls in the observation window
+            call_count = _count_change_rrs_calls(since_seconds=ALIAS_IDLE_WAIT + 30)
+
+            # With the fix, only the initial create call should have fired.
+            # A perpetual update loop would produce many more calls.
+            assert call_count <= FIX_MAX_CALLS, (
+                f"Perpetual update loop detected: {call_count} ChangeResourceRecordSets calls "
+                f"observed in {ALIAS_IDLE_WAIT}s (max allowed: {FIX_MAX_CALLS}). "
+                "The alias record normalization fix may not be active."
+            )
+
+            # Verify the alias record is still synced (not stuck in error)
+            assert k8s.wait_on_condition(alias_ref, "ACK.ResourceSynced", "True", wait_periods=5), \
+                "Alias A record lost ACK.ResourceSynced=True after idle period"
+
+        finally:
+            if alias_ref is not None:
+                delete_route53_resource(alias_ref)
+            if base_ref is not None:
+                delete_route53_resource(base_ref)


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2982

Also fixes: https://github.com/aws-controllers-k8s/community/issues/2987

Route53 returns `AliasTarget.DNSName` with a trailing dot (e.g. `d-xxxxx.execute-api.us-east-1.amazonaws.com.`) and `AliasTarget.HostedZoneID` with a `/hostedzone/` prefix. The ACK controller spec stores values without these decorations. The raw string comparison in generated `delta.go` always finds a difference, causing the controller to call `ChangeResourceRecordSets` on every reconcile loop — resulting in infinite perpetual updates.

## Fix

Add a `delta_pre_compare` hook (`customPreCompare`) that normalizes both sides of the comparison before the generated diff runs:
- Strip trailing dot from `AliasTarget.DNSName`
- Strip `/hostedzone/` prefix from `AliasTarget.HostedZoneID`

This is the same pattern used in the HostedZone resource for tag and VPC comparison.

## Testing

- 7 unit subtests in `hooks_test.go` covering all normalization cases
- E2E: alias record perpetual loop reproduced on upstream, confirmed absent with this fix

Fixes: R53-3, R53-4
