### PR TITLE
fix(RecordSet): make adoption id field optional in pre/post annotation hooks

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -143,6 +143,8 @@ resources:
         template_path: hooks/record_set/sdk_read_many_post_set_output.go.tpl
       post_set_resource_identifiers:
         template_path: hooks/record_set/post_set_resource_identifiers.go.tpl
+      pre_populate_resource_from_annotation:
+        template_path: hooks/record_set/pre_populate_resource_from_annotation.go.tpl
       post_populate_resource_from_annotation:
         template_path: hooks/record_set/post_populate_resource_from_annotation.go.tpl
     list_operation:

--- a/generator.yaml
+++ b/generator.yaml
@@ -143,6 +143,8 @@ resources:
         template_path: hooks/record_set/sdk_read_many_post_set_output.go.tpl
       post_set_resource_identifiers:
         template_path: hooks/record_set/post_set_resource_identifiers.go.tpl
+      pre_populate_resource_from_annotation:
+        template_path: hooks/record_set/pre_populate_resource_from_annotation.go.tpl
       post_populate_resource_from_annotation:
         template_path: hooks/record_set/post_populate_resource_from_annotation.go.tpl
     list_operation:

--- a/pkg/resource/record_set/resource.go
+++ b/pkg/resource/record_set/resource.go
@@ -112,6 +112,15 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
+
+	// id maps to Status.ID (ChangeInfo ID). It is intentionally optional for
+	// adoption of pre-existing records, which have no associated ChangeInfo.
+	// Inject an empty string so that the generated required-field check passes;
+	// the post hook will clear Status.ID when the injected empty value is found.
+	if _, ok := fields["id"]; !ok {
+		fields["id"] = ""
+	}
+
 	primaryKey, ok := fields["id"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: id"))
@@ -122,6 +131,12 @@ func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) erro
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: hostedZoneID"))
 	}
 	r.ko.Spec.HostedZoneID = &f0
+
+	// If the pre hook injected an empty "id" sentinel (absent from annotation),
+	// clear Status.ID so that sdkFind skips the ChangeInfo lookup.
+	if r.ko.Status.ID != nil && *r.ko.Status.ID == "" {
+		r.ko.Status.ID = nil
+	}
 
 	if f1, f1ok := fields["recordType"]; f1ok {
 		r.ko.Spec.RecordType = &f1

--- a/pkg/resource/record_set/resource_test.go
+++ b/pkg/resource/record_set/resource_test.go
@@ -1,0 +1,79 @@
+package record_set
+
+import (
+	"testing"
+
+	svcapitypes "github.com/aws-controllers-k8s/route53-controller/apis/v1alpha1"
+)
+
+func Test_PopulateResourceFromAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		fields       map[string]string
+		wantID       *string
+		wantErr      bool
+		wantTerminal bool
+	}{
+		{
+			name: "id present — sets Status.ID",
+			fields: map[string]string{
+				"id":           "C1234ABCDE",
+				"hostedZoneID": "Z1234",
+			},
+			wantID: strPtr("C1234ABCDE"),
+		},
+		{
+			name: "id absent — adoption of pre-existing record succeeds",
+			fields: map[string]string{
+				"hostedZoneID": "Z1234",
+			},
+			wantID: nil,
+		},
+		{
+			name: "id empty string — treated as absent",
+			fields: map[string]string{
+				"id":           "",
+				"hostedZoneID": "Z1234",
+			},
+			wantID: nil,
+		},
+		{
+			name: "hostedZoneID absent — terminal error",
+			fields: map[string]string{
+				"id": "C1234ABCDE",
+			},
+			wantErr:      true,
+			wantTerminal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &resource{ko: &svcapitypes.RecordSet{}}
+			err := r.PopulateResourceFromAnnotation(tt.fields)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantID == nil {
+				if r.ko.Status.ID != nil {
+					t.Errorf("expected Status.ID nil, got %q", *r.ko.Status.ID)
+				}
+			} else {
+				if r.ko.Status.ID == nil {
+					t.Errorf("expected Status.ID %q, got nil", *tt.wantID)
+				} else if *r.ko.Status.ID != *tt.wantID {
+					t.Errorf("Status.ID = %q, want %q", *r.ko.Status.ID, *tt.wantID)
+				}
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/pkg/resource/record_set/sdk.go
+++ b/pkg/resource/record_set/sdk.go
@@ -293,7 +293,7 @@ func (rm *resourceManager) sdkFind(
 	// created/updated by this controller), we skip the propagation check.
 	// The record was confirmed to exist via ListResourceRecordSets, so it is
 	// already present on the authoritative servers.
-	if ko.Status.ID != nil {
+	if ko.Status.ID != nil && *ko.Status.ID != "" {
 		err = rm.syncStatus(ctx, ko)
 		if err != nil {
 			return nil, err

--- a/templates/hooks/record_set/post_populate_resource_from_annotation.go.tpl
+++ b/templates/hooks/record_set/post_populate_resource_from_annotation.go.tpl
@@ -1,3 +1,9 @@
+	// If the pre hook injected an empty "id" sentinel (absent from annotation),
+	// clear Status.ID so that sdkFind skips the ChangeInfo lookup.
+	if r.ko.Status.ID != nil && *r.ko.Status.ID == "" {
+		r.ko.Status.ID = nil
+	}
+
 	if f1, f1ok := fields["recordType"]; f1ok {
 		r.ko.Spec.RecordType = &f1
 	}

--- a/templates/hooks/record_set/pre_populate_resource_from_annotation.go.tpl
+++ b/templates/hooks/record_set/pre_populate_resource_from_annotation.go.tpl
@@ -1,0 +1,8 @@
+
+	// id maps to Status.ID (ChangeInfo ID). It is intentionally optional for
+	// adoption of pre-existing records, which have no associated ChangeInfo.
+	// Inject an empty string so that the generated required-field check passes;
+	// the post hook will clear Status.ID when the injected empty value is found.
+	if _, ok := fields["id"]; !ok {
+		fields["id"] = ""
+	}

--- a/templates/hooks/record_set/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/record_set/sdk_read_many_post_set_output.go.tpl
@@ -7,7 +7,7 @@
 	// created/updated by this controller), we skip the propagation check.
 	// The record was confirmed to exist via ListResourceRecordSets, so it is
 	// already present on the authoritative servers.
-	if ko.Status.ID != nil {
+	if ko.Status.ID != nil && *ko.Status.ID != "" {
 		err = rm.syncStatus(ctx, ko)
 		if err != nil {
 			return nil, err

--- a/test/e2e/resources/record_set_adopt_no_id.yaml
+++ b/test/e2e/resources/record_set_adopt_no_id.yaml
@@ -1,0 +1,14 @@
+apiVersion: route53.services.k8s.aws/v1alpha1
+kind: RecordSet
+metadata:
+  name: $ADOPT_RECORD_NAME
+  annotations:
+    services.k8s.aws/adoption-policy: adopt
+    services.k8s.aws/adoption-fields: '{"hostedZoneID":"$HOSTED_ZONE_ID","name":"$ADOPT_RECORD_DNS_NAME","recordType":"$RECORD_TYPE"}'
+spec:
+  name: $ADOPT_RECORD_DNS_NAME
+  hostedZoneID: $HOSTED_ZONE_ID
+  recordType: $RECORD_TYPE
+  resourceRecords:
+  - value: $IP_ADDR
+  ttl: 300

--- a/test/e2e/tests/test_record_set.py
+++ b/test/e2e/tests/test_record_set.py
@@ -337,3 +337,102 @@ class TestRecordSet:
             except route53_client.exceptions.InvalidChangeBatch:
                 # Record already deleted by the controller
                 pass
+
+    def test_adopt_with_adoption_fields_no_id(self, route53_client, private_hosted_zone):
+        """Test the exact CX scenario: adopt a pre-existing record using adoption-fields
+        annotation with hostedZoneID + name + recordType but WITHOUT an id field.
+
+        On upstream (buggy): controller returns terminal error 'required field missing: id'
+        With fix: controller successfully adopts the record, Status.ID is nil, Synced=True.
+
+        This directly reproduces the customer scenario where pre-existing Route53 records
+        (not created by ACK) have no ChangeInfo ID and should be adoptable without one.
+        """
+        zone_id, domain = private_hosted_zone
+        parsed_zone_id = zone_id.split("/")[-1]
+        ip_address = socket.inet_ntoa(struct.pack('>I', random.randint(1, 0xffffffff)))
+        record_dns_name = "adopt-no-id-test"
+        full_dns_name = f"{record_dns_name}.{domain}"
+
+        # Step 1: Create a real AWS record via boto3 (simulating a pre-existing resource
+        # that was NOT created by ACK and therefore has no ChangeInfo ID)
+        route53_client.change_resource_record_sets(
+            HostedZoneId=parsed_zone_id,
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": "CREATE",
+                        "ResourceRecordSet": {
+                            "Name": full_dns_name,
+                            "Type": "A",
+                            "TTL": 300,
+                            "ResourceRecords": [{"Value": ip_address}],
+                        },
+                    }
+                ]
+            },
+        )
+
+        ref = None
+        try:
+            # Step 2: Adopt it using 'adopt' policy + adoption-fields with NO 'id' field.
+            # This is the exact CX scenario: hostedZoneID + name + recordType only.
+            adopt_record_name = random_suffix_name("adopt-no-id", 32)
+            replacements = REPLACEMENT_VALUES.copy()
+            replacements["ADOPT_RECORD_NAME"] = adopt_record_name
+            replacements["ADOPT_RECORD_DNS_NAME"] = record_dns_name
+            replacements["HOSTED_ZONE_ID"] = parsed_zone_id
+            replacements["RECORD_TYPE"] = "A"
+            replacements["IP_ADDR"] = ip_address
+
+            resource_data = load_eks_resource(
+                "record_set_adopt_no_id",
+                additional_replacements=replacements,
+            )
+
+            ref = k8s.CustomResourceReference(
+                CRD_GROUP, CRD_VERSION, "recordsets",
+                adopt_record_name, namespace="default",
+            )
+            k8s.create_custom_resource(ref, resource_data)
+            cr = k8s.wait_resource_consumed_by_controller(ref)
+            assert cr is not None
+
+            # Step 3: Assert ACK.ResourceSynced=True (fix) or confirm ACK.Terminal=True (bug).
+            # With the fix, adoption succeeds and Status.ID is nil (no ChangeInfo).
+            # Without the fix, the controller sets ACK.Terminal=True with error:
+            #   "required field missing: id"
+            assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10), \
+                "Expected ACK.ResourceSynced=True after adoption without id field. " \
+                "If ACK.Terminal=True with 'required field missing: id', the fix is not applied."
+
+            # Verify Status.ID is nil — adoption of pre-existing records has no ChangeInfo ID
+            record = get_route53_resource(ref)
+            assert record["status"].get("id") is None, \
+                f"Expected Status.ID to be nil for adopted record, got: {record['status'].get('id')}"
+        finally:
+            # Step 4: Clean up both the K8s CR and the AWS record
+            if ref is not None:
+                delete_route53_resource(ref)
+
+            # Ensure the AWS record is removed even if the K8s delete fails
+            try:
+                route53_client.change_resource_record_sets(
+                    HostedZoneId=parsed_zone_id,
+                    ChangeBatch={
+                        "Changes": [
+                            {
+                                "Action": "DELETE",
+                                "ResourceRecordSet": {
+                                    "Name": full_dns_name,
+                                    "Type": "A",
+                                    "TTL": 300,
+                                    "ResourceRecords": [{"Value": ip_address}],
+                                },
+                            }
+                        ]
+                    },
+                )
+            except route53_client.exceptions.InvalidChangeBatch:
+                # Record already deleted by the controller
+                pass


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2981

When adopting a pre-existing Route53 record via the `adoption-fields` annotation, customers omit the `id` field because pre-existing records have no associated ChangeInfo ID. The generated `PopulateResourceFromAnnotation` treats `id` as required and returns a terminal error: `required field missing: id`.

## Fix

Add `pre_populate_resource_from_annotation` hook that injects an empty `id` sentinel when the field is absent from the annotation map, allowing the required-field check to pass. A `post_populate_resource_from_annotation` hook then clears `Status.ID` so the ChangeInfo lookup in `sdkFind` is skipped for adopted records with no ChangeInfo.

## Testing

- 4 unit subtests in `resource_test.go`
- E2E: adoption with `adoption-fields` annotation (no `id`) reproduced terminal error on upstream, confirmed Synced=True with this fix

Fixes: R53-2
