### PR TITLE
Stop unbounded GetChange polling on INSYNC RecordSet changes

### DIFF
--- a/pkg/resource/record_set/hooks.go
+++ b/pkg/resource/record_set/hooks.go
@@ -265,6 +265,17 @@ func (rm *resourceManager) syncStatus(
 		return nil
 	}
 
+	// INSYNC is a terminal state for a change batch: once a change has fully
+	// propagated to all Route 53 authoritative DNS servers it never reverts to
+	// PENDING. Since the change ID is persisted on the CR status and is never
+	// cleared, re-polling GetChange on every reconcile would issue an unbounded
+	// stream of calls against the same long-settled change ID. Short-circuit
+	// here so we stop polling once the change is INSYNC.
+	if ko.Status.Status != nil &&
+		svcsdktypes.ChangeStatus(*ko.Status.Status) == svcsdktypes.ChangeStatusInsync {
+		return nil
+	}
+
 	changeInput := &svcsdk.GetChangeInput{}
 	changeInput.Id = ko.Status.ID
 

--- a/pkg/resource/record_set/hooks_test.go
+++ b/pkg/resource/record_set/hooks_test.go
@@ -1,7 +1,11 @@
 package record_set
 
 import (
+	"context"
 	"testing"
+
+	svcapitypes "github.com/aws-controllers-k8s/route53-controller/apis/v1alpha1"
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 func Test_getDNSName(t *testing.T) {
@@ -50,6 +54,68 @@ func Test_getDNSName(t *testing.T) {
 			got := rm.getDNSName(tt.recordName, tt.domain)
 			if got != tt.want {
 				t.Errorf("getDNSName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// callsGetChange reports whether syncStatus proceeded past its short-circuit
+// checks to the GetChange API call. rm is constructed with a nil sdkapi, so
+// reaching the API call panics on the nil pointer dereference; we recover that
+// panic and treat it as "the API path was taken". A clean return means
+// syncStatus short-circuited without polling GetChange.
+func callsGetChange(ko *svcapitypes.RecordSet) (called bool) {
+	rm := &resourceManager{}
+	defer func() {
+		if recover() != nil {
+			called = true
+		}
+	}()
+	_ = rm.syncStatus(context.Background(), ko)
+	return false
+}
+
+func Test_syncStatus_skipsPollWhenInsync(t *testing.T) {
+	tests := []struct {
+		testName        string
+		id              *string
+		status          *string
+		wantCallsChange bool
+	}{
+		{
+			testName:        "no change ID skips poll",
+			id:              nil,
+			status:          aws.String("INSYNC"),
+			wantCallsChange: false,
+		},
+		{
+			testName:        "INSYNC change is terminal and skips poll",
+			id:              aws.String("/change/C1234567890"),
+			status:          aws.String("INSYNC"),
+			wantCallsChange: false,
+		},
+		{
+			testName:        "PENDING change is re-polled",
+			id:              aws.String("/change/C1234567890"),
+			status:          aws.String("PENDING"),
+			wantCallsChange: true,
+		},
+		{
+			testName:        "nil status with change ID is re-polled",
+			id:              aws.String("/change/C1234567890"),
+			status:          nil,
+			wantCallsChange: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			ko := &svcapitypes.RecordSet{}
+			ko.Status.ID = tt.id
+			ko.Status.Status = tt.status
+
+			if got := callsGetChange(ko); got != tt.wantCallsChange {
+				t.Errorf("syncStatus polled GetChange = %v, want %v", got, tt.wantCallsChange)
 			}
 		})
 	}


### PR DESCRIPTION
Issue #, if available: Fixes aws-controllers-k8s/community#2994

Description of changes:
- Does not call GetChange on already terminal-state INSYNC changes
- Adds unit coverage in Test_syncStatus_skipsPollWhenInsync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
